### PR TITLE
Fix for non-local Almond installations

### DIFF
--- a/pyalmond/__init__.py
+++ b/pyalmond/__init__.py
@@ -70,7 +70,7 @@ class AlmondLocalAuth(AbstractAlmondAuth):
 
     async def async_get_auth_headers(self) -> dict:
         """Get the request auth headers."""
-        return {"origin": "http://127.0.0.1:3000"}
+        return {"origin": self.host}
 
 
 class AbstractAlmondWebAuth(AbstractAlmondAuth):


### PR DESCRIPTION
As found by @markusressel in https://github.com/stanford-oval/almond-server/issues/37#issuecomment-569167270, when Almond installed on a different server than localhost, the origin header is not properly set up. This PR fixes the issue and allows to integrate Home Assistant to Almond when Almond and HA are not on the same host.